### PR TITLE
Result ordering (asc|de?sc) not working - implemented fix

### DIFF
--- a/client/assets/js/app.js
+++ b/client/assets/js/app.js
@@ -594,7 +594,7 @@ function setDefaultOptions(loadedOption, defaultOption) {
 					sortRegex.lastIndex = 0;
 					var key = rgxArr[1];
 					var ord = rgxArr[2].toLowerCase().replace("dsc", "desc");
-					key = evalSearchTermFieldKey(key);
+					key = searchterm.evalSearchTermFieldKey(key);
 					// special handle for 'shop.hasPrice'
 					if (key === "shop.hasPrice") {
 						key = "shop.chaosEquiv";

--- a/client/assets/js/searchterm.js
+++ b/client/assets/js/searchterm.js
@@ -322,5 +322,5 @@ var searchterm = (function (util) {
   return {
     parseSearchInput: parseSearchInput,
 	evalSearchTermFieldKey: evalSearchTermFieldKey
-  }
+  };
 }(util));

--- a/client/assets/js/searchterm.js
+++ b/client/assets/js/searchterm.js
@@ -321,6 +321,6 @@ var searchterm = (function (util) {
 
   return {
     parseSearchInput: parseSearchInput,
-	evalSearchTermFieldKey: evalSearchTermFieldKey
+    evalSearchTermFieldKey: evalSearchTermFieldKey
   };
 }(util));

--- a/client/assets/js/searchterm.js
+++ b/client/assets/js/searchterm.js
@@ -320,6 +320,7 @@ var searchterm = (function (util) {
   }
 
   return {
-    parseSearchInput: parseSearchInput
+    parseSearchInput: parseSearchInput,
+	evalSearchTermFieldKey: evalSearchTermFieldKey
   }
 }(util));


### PR DESCRIPTION
`doActualSearch` in `app.js` has picked up a bug due to the recent creation/moving of `searchterm.js` and it is no longer able to invoke the method `evalSearchTermFieldKey`, breaking the ability to sort by specific mods.

The fix is relatively trivial, but would restore a very helpful feature to the site.
